### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   test:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/rawbytedev/CrossTrace/security/code-scanning/1](https://github.com/rawbytedev/CrossTrace/security/code-scanning/1)

To fix the flagged issue, add an explicit `permissions` block to the workflow, limiting the GITHUB_TOKEN permissions to the minimum required. For this workflow, the minimal starting point is `contents: read`, which allows jobs to read repository content but not push or modify it. This block should be added at the job level (i.e., inside the `test` job, above `runs-on: ubuntu-latest:`) for maximum clarity. No other file or line changes are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
