### PR TITLE
Potential fix for code scanning alert no. 2: Incorrect conversion between integer types

### DIFF
--- a/internal/journal/database/badger.go
+++ b/internal/journal/database/badger.go
@@ -20,7 +20,8 @@ package database
 
 import (
 	dbconfig "crosstrace/internal/configs"
-
+	"math"
+	"fmt"
 	"github.com/dgraph-io/badger/v4"
 )
 
@@ -39,6 +40,9 @@ func NewBadgerdb(cfg dbconfig.JournalConfig) (StorageDB, error) {
 		size, err := dbconfig.ParseSize(cfg.LogSize)
 		if err != nil {
 			return nil, err
+		}
+		if size > uint64(math.MaxInt64) {
+			return nil, fmt.Errorf("log size %d bytes exceeds maximum supported value (%d)", size, int64(math.MaxInt64))
 		}
 		opts = opts.WithValueLogFileSize(int64(size))
 	}


### PR DESCRIPTION
Potential fix for [https://github.com/rawbytedev/CrossTrace/security/code-scanning/2](https://github.com/rawbytedev/CrossTrace/security/code-scanning/2)

To fix the problem, ensure that before converting the `uint64` value returned by `ParseSize` to `int64`, its value is checked so it cannot exceed `math.MaxInt64`, the maximum possible int64 value. If the value exceeds this boundary (or is zero, if that's not valid for the use-case), handle the error gracefully (here, by returning an error).  
You only need to fix the code in `internal/journal/database/badger.go` at the line where `int64(size)` is used.  
You should import the `math` package at the top to use `math.MaxInt64` (if it is not present already in this file).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
